### PR TITLE
Update versions, fix elastic config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ The current variables can be found in `elk/variables` section
 
 ```yaml
   variables:
-    elasticsearch-image-tag: 7.9.0
+    elasticsearch-image-tag: 8.15.3
     elasticsearch-jvm-options: "-Xmx256m -Xms256m"
     elasticsearch-http-port: 9200
     elasticsearch-internal-port: 9300
     kibana-http-port: 5601
-    kibana-image-tag: 7.9.0
-    logstash-image-tag: 7.17.5
+    kibana-image-tag: 8.15.3
+    logstash-image-tag: 8.15.3
     logstash-jvm-options: "-Xmx256m -Xms256m"   
     logstash-http-port: 9600
     nginx-listen-port: 8080
@@ -62,13 +62,13 @@ You can find configuration files in `/files` directory in repository and can edi
 
 | Variable                        | Description                                                  | Type   | Example             |
 | ------------------------------- | ------------------------------------------------------------ | ------ | ------------------- |
-| **elasticsearch-image-tag**     | Elasticsearch image version.                                 | string | 7.9.0               |
+| **elasticsearch-image-tag**     | Elasticsearch image version.                                 | string | 8.15.3               |
 | **elasticsearch-jvm-options**   | Elasticsearch jvm options.                                   | string | "-Xmx256m -Xms256m" |
 | **elasticsearch-http-port**     | Elasticsearch port that will accept requests                 | int    | 9200                |
 | **elasticsearch-internal-port** | Elasticsearch custom port for the node to node communication | int    | 9300                |
 | **kibana-http-port**            | Kibana http port for UI                                      | int    | 9300                |
-| **kibana-image-tag**            | Kibana image version.                                        | string | 7.9.0               |
-| **logstash-image-tag**          | Logstash image version.                                      | string | 7.17.5              |
+| **kibana-image-tag**            | Kibana image version.                                        | string | 8.15.3               |
+| **logstash-image-tag**          | Logstash image version.                                      | string | 8.15.3             |
 | **logstash-jvm-options**        | Logstash jvm options.                                        | string | "-Xmx256m -Xms256m" |
 | **logstash-http-port**          | Logstash port that will accept requests                      | int    | 9600                |
 | **nginx-listen-port**           | Configures the ports that the nginx listens on.              | int    | 80                  |

--- a/elk-stack.yaml
+++ b/elk-stack.yaml
@@ -41,7 +41,7 @@ elasticsearch:
       contents: <<< files/elasticsearch.yml
   variables:
     elasticsearch-image:
-      value: <- $elasticsearch-image-tag default("7.9.0")
+      value: <- $elasticsearch-image-tag default("8.15.3")
       type: string
     jvm-opts:
       env: ES_JAVA_OPTS
@@ -104,7 +104,7 @@ kibana:
       contents: <<< files/kibana.yml
   variables:
     kibana-image:
-      value: <- $kibana-image-tag default("7.9.0")
+      value: <- $kibana-image-tag default("8.15.3")
       type: string
     elasticsearch-hosts:
       type: string
@@ -171,7 +171,7 @@ logstash:
       contents: <<< files/pipeline/logstash.conf
   variables:
     logstash-image:
-      value: <- $logstash-image-tag default("7.17.5")
+      value: <- $logstash-image-tag default("8.15.3")
       type: string
     elasticsearch-hosts:
       type: string

--- a/files/elasticsearch.yml
+++ b/files/elasticsearch.yml
@@ -3,7 +3,7 @@
 #
 # Set a custom port for the node to node communication (9300 by default):
 
-transport.tcp.port: {{ v "internal-port" }}
+transport.port: {{ v "internal-port" }}
 
 
 # Set a custom port to listen for HTTP traffic:

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,7 +24,7 @@ stack:
     - elk/nginx
   variables:
     elasticsearch-image-tag:
-      value: 7.9.0
+      value: 8.15.3
       type: string
     elasticsearch-jvm-options:
       value: -Xmx256m -Xms256m
@@ -39,10 +39,10 @@ stack:
       value: 5601
       type: int
     kibana-image-tag:
-      value: 7.9.0
+      value: 8.15.3
       type: string
     logstash-image-tag:
-      value: 7.17.5
+      value: 8.15.3
       type: string
     logstash-jvm-options:
       value: -Xmx256m -Xms256m


### PR DESCRIPTION
This pull request updates the ELK stack configuration to use the latest 8.15.3 image versions for Elasticsearch, Kibana, and Logstash, and updates related documentation and configuration files accordingly. It also corrects a configuration parameter in the Elasticsearch YAML file to align with newer Elasticsearch versions.

**Version upgrades and configuration updates:**

* Updated the default image tags for `elasticsearch`, `kibana`, and `logstash` from older 7.x/7.17.5 versions to 8.15.3 in `elk-stack.yaml` and the `README.md` documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R43) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R71) [[3]](diffhunk://#diff-935a63cfd937db3cee839f5b9f6ce924dd8bf290944c87b926d1ba35a0c25a78L44-R44) [[4]](diffhunk://#diff-935a63cfd937db3cee839f5b9f6ce924dd8bf290944c87b926d1ba35a0c25a78L107-R107) [[5]](diffhunk://#diff-935a63cfd937db3cee839f5b9f6ce924dd8bf290944c87b926d1ba35a0c25a78L174-R174)

**Configuration parameter correction:**

* Changed `transport.tcp.port` to `transport.port` in `files/elasticsearch.yml` to match the updated configuration key used in Elasticsearch 8.x.